### PR TITLE
better feature naming

### DIFF
--- a/src/output_datasets.jl
+++ b/src/output_datasets.jl
@@ -767,9 +767,5 @@ function get_vnames(
     ds::MultidimDataset{<:Any,<:AggregateFeat};
     groupby_split::Bool=false
 )
-    names =
-        ["$(f.vname),$(f.feat),win:$(f.nwin)" for f in ds.info]
-    # groupby_split && has_groups(ds) ?
-    #     [names[g] for g in get_groups(ds)] :
-    #     names
+    ["$(f.vname)_$(f.feat)_win_$(f.nwin)" for f in ds.info]
 end


### PR DESCRIPTION
Previously featurenames contains "," and ":" it was nice, but if we need to manipulate them with regex, could be a nightmare. Now everything was replaced with a safe "_".